### PR TITLE
Prevent syntax error in unpacking nested arrays into loop variables

### DIFF
--- a/src/Logchecker.php
+++ b/src/Logchecker.php
@@ -1024,7 +1024,7 @@ class Logchecker {
 			$MatchedDrives[$i] = ['drives' => [], 'offsets' => []];
 		}
 
-		foreach ($this->AllDrives as [$Drive, $Offset]) {
+		foreach ($this->AllDrives as list($Drive, $Offset)) {
 			$Distance = levenshtein($Drive, $DriveName);
 			if ($Distance < 5) {
 				$MatchedDrives[$Distance]['drives'][] = $Drive;


### PR DESCRIPTION
Solves (my) issue #8.

Ref: http://php.net/manual/en/control-structures.foreach.php#control-structures.foreach.list