### PR TITLE
Use symfony/process instead of shell_exec

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "ext-mbstring": "*",
         "symfony/console": "^3.4",
         "symfony/debug": "^3.4",
-        "symfony/yaml": "^3.4"
+        "symfony/yaml": "^3.4",
+        "symfony/process": "^5.0"
     },
     "bin": ["bin/logchecker"]
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/console": "^3.4",
         "symfony/debug": "^3.4",
         "symfony/yaml": "^3.4",
-        "symfony/process": "^5.0"
+        "symfony/process": "^3"
     },
     "bin": ["bin/logchecker"]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ad854c65da76498f6a2af058812e332",
+    "content-hash": "bda3c6cb822164941a9e71f909c7468a",
     "packages": [
         {
             "name": "psr/log",
@@ -297,6 +297,55 @@
                 "shim"
             ],
             "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "fd4a86dd7e36437f2fc080d8c42c7415d828a0a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/fd4a86dd7e36437f2fc080d8c42c7415d828a0a8",
+                "reference": "fd4a86dd7e36437f2fc080d8c42c7415d828a0a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-02-08T17:00:58+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bda3c6cb822164941a9e71f909c7468a",
+    "content-hash": "260e7772b01066cf4e3ce40e4933b07a",
     "packages": [
         {
             "name": "psr/log",
@@ -300,25 +300,25 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.0.5",
+            "version": "v3.4.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "fd4a86dd7e36437f2fc080d8c42c7415d828a0a8"
+                "reference": "b03b02dcea26ba4c65c16a73bab4f00c186b13da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/fd4a86dd7e36437f2fc080d8c42c7415d828a0a8",
-                "reference": "fd4a86dd7e36437f2fc080d8c42c7415d828a0a8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b03b02dcea26ba4c65c16a73bab4f00c186b13da",
+                "reference": "b03b02dcea26ba4c65c16a73bab4f00c186b13da",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -345,7 +345,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-02-08T17:00:58+00:00"
+            "time": "2020-02-04T08:04:52+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/Chardet.php
+++ b/src/Chardet.php
@@ -3,6 +3,7 @@
 namespace OrpheusNET\Logchecker;
 
 use OrpheusNET\Logchecker\Exception\{FileNotFoundException};
+use Symfony\Component\Process\Process;
 
 class Chardet {
     private $executable = null;
@@ -29,8 +30,10 @@ class Chardet {
         if (!file_exists($filename)) {
             throw new FileNotFoundException($filename);
         }
+		$process = new Process([$this->executable, $filename]);
+        $process->run();
+		$output = $process->getOutput();
 
-        $output = shell_exec($this->executable . " " . escapeshellarg($filename));
         // Following regex:
         //    matches[1] - file path
         //    matches[2] - charset

--- a/src/Logchecker.php
+++ b/src/Logchecker.php
@@ -2,6 +2,7 @@
 
 namespace OrpheusNET\Logchecker;
 
+use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
 
@@ -466,7 +467,10 @@ class Logchecker {
 				}
 
 				if (Util::commandExists($Command)) {
-					$Out = shell_exec("{$Command} ".escapeshellarg($this->LogPath));
+					$process = new Process([$Command, $this->LogPath]);
+					$process->run();
+					$Out = $process->getOutput();
+
 					if ($Out == null || Util::strposArray($Out, $BadStrings) !== false || strpos($Out, $GoodString) === false) {
 						$this->Checksum = false;
 					}


### PR DESCRIPTION
The shell_exec calls reported that the log file was not found even if a PHP file_exists said that it was there. I guess there is something with the escaping of the shell argument, so I added symfony/process to project and used that instead of shell_exec and escapeshellarg. My experience with symfony/process is that the escaping works very well and it fixed the problem here.